### PR TITLE
Added PSVersion check for Powershell 7

### DIFF
--- a/Run.ps1
+++ b/Run.ps1
@@ -41,6 +41,7 @@ For more information, visit:
 }
 
 # Import scripts
+. ([System.IO.Path]::Combine($PSScriptRoot, 'scripts/test-psversion.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'scripts/shared.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'scripts/test-generator.ps1'))
 . ([System.IO.Path]::Combine($PSScriptRoot, 'scripts/maester-code-generator.ps1'))

--- a/scripts/test-psversion.ps1
+++ b/scripts/test-psversion.ps1
@@ -1,0 +1,33 @@
+[CmdletBinding()]
+param()
+    
+    $minimumVersion = [Version]"7.0.0"
+    $currentVersion = $PSVersionTable.PSVersion
+    
+    if ($currentVersion -lt $minimumVersion) {
+        Write-Host "Error: This script requires PowerShell 7.0 or higher." -ForegroundColor Red
+        Write-Host "Current PowerShell version: $($currentVersion)" -ForegroundColor Red
+        Write-Host "Please install PowerShell 7 from https://github.com/PowerShell/PowerShell/releases" -ForegroundColor Yellow
+        
+        # Check if pwsh is installed but script was run in older version
+        if (Get-Command pwsh -ErrorAction SilentlyContinue) {
+            Write-Host "`nPowerShell 7 appears to be installed. You can run this script with:" -ForegroundColor Cyan
+            Write-Host "pwsh -File `"$($MyInvocation.PSCommandPath)`"" -ForegroundColor Cyan
+
+            # Ask if they want to relaunch with PowerShell 7
+            do {
+                $response = Read-Host "Would you like to run this script using PowerShell 7 now? (Y/N)"
+            } while ($response -notmatch '^(Y|y|N|n)$')
+
+            if ($response -match '^(Y|y)$') {
+                Start-Process -FilePath "pwsh" -ArgumentList "-File `"$($MyInvocation.PSCommandPath)`"" -NoNewWindow
+            } else {
+                Write-Host "Script execution stopped." -ForegroundColor Yellow
+            }
+        }
+        
+        # Stop script execution
+        exit
+    }
+    
+    Write-Host "PowerShell version check passed: Running PowerShell $currentVersion" -ForegroundColor Green


### PR DESCRIPTION
## What's Added in `test-psversion.ps1`:

- **PowerShell 7.0+ version requirement check**
- **Automatic detection of existing PowerShell 7 installation**
- **Interactive prompt to auto-relaunch with correct PowerShell version**
- **Color-coded error messages and user guidance**
- **Graceful script termination for incompatible versions**
- **Success confirmation when version check passes**

This ensures the Conditional Access Validator tools run on the required PowerShell version before execution.